### PR TITLE
Add onboarding and assistant panel overlay

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,7 +4,8 @@ import ChatBar from './components/ChatBar';
 import CommandInput from './components/CommandInput';
 import { DELOInterface } from './components/DELOInterface';
 import Settings from './components/Settings';
-import FloatingOrb from './components/FloatingOrb';
+import DELOAssistantPanel from './components/DELOAssistantPanel';
+import Onboarding from './components/Onboarding';
 import RealTimeOverlay from './components/RealTimeOverlay';
 import GlassmorphicOverlay from './components/GlassmorphicOverlay';
 
@@ -41,6 +42,9 @@ const App: React.FC = () => {
     theme: 'auto'
   });
 
+  const [showOnboarding, setShowOnboarding] = useState(false);
+  const [showAssistant, setShowAssistant] = useState(false);
+
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [position, setPosition] = useState({ x: 50, y: 50 });
@@ -67,6 +71,26 @@ const App: React.FC = () => {
 
     return () => mediaQuery.removeEventListener('change', handleThemeChange);
   }, [state.theme]);
+
+  useEffect(() => {
+    const done = localStorage.getItem('delo-onboarded');
+    if (!done) {
+      setShowOnboarding(true);
+    } else {
+      setShowAssistant(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.shiftKey && e.altKey && e.code === 'Space') {
+        e.preventDefault();
+        setShowAssistant(prev => !prev);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -339,6 +363,25 @@ const App: React.FC = () => {
           <div className="settings-overlay">
             <Settings />
           </div>
+        )}
+
+        {showAssistant && (
+          <DELOAssistantPanel
+            isVisible={true}
+            onClose={() => setShowAssistant(false)}
+            onSubmit={handleDELOCommand}
+            onVoice={() => console.log('voice')}
+          />
+        )}
+
+        {showOnboarding && (
+          <Onboarding
+            onComplete={() => {
+              localStorage.setItem('delo-onboarded', 'true');
+              setShowOnboarding(false);
+              setShowAssistant(true);
+            }}
+          />
         )}
       </div>
     </div>

--- a/src/renderer/components/DELOAssistantPanel.tsx
+++ b/src/renderer/components/DELOAssistantPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Mic, Send, X } from 'lucide-react';
+import { Mic, Send } from 'lucide-react';
 
 interface DELOAssistantPanelProps {
   isVisible: boolean;
@@ -78,51 +78,49 @@ const DELOAssistantPanel: React.FC<DELOAssistantPanelProps> = ({
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: -24, scale: 0.98 }}
             transition={{ duration: 0.25, ease: 'easeOut' }}
-            className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 transition-opacity transition-transform duration-500 opacity-100 scale-100 bg-white/10 backdrop-blur-xl border border-white/20 rounded-2xl shadow-xl px-6 py-6 max-w-xl w-full h-auto flex flex-col items-center gap-4"
-            style={{ boxSizing: "border-box" }}
+            className="transition-opacity transition-transform duration-500 bg-white/10 backdrop-blur-xl border border-white/20 rounded-2xl shadow-xl px-6 py-6 max-w-[600px] w-full h-auto flex flex-col items-center"
+            style={{ boxSizing: 'border-box' }}
             onClick={e => e.stopPropagation()}
           >
-            {/* Close button */}
-            <button
-              onClick={onClose}
-              className="absolute top-3 right-3 w-8 h-8 flex items-center justify-center rounded-xl bg-white/10 border border-white/20 text-white/80 hover:bg-white/20 transition-all duration-200 z-10"
-              aria-label="Close"
-            >
-              <X className="w-4 h-4" />
-            </button>
             {/* Status label */}
-            <div className="text-center text-sm font-semibold text-blue-400 drop-shadow-md animate-pulse mb-2 select-none">
-              <span className="glow-blue">{status}</span>
+            <div className="text-sm text-blue-300 animate-pulse text-center mb-3">
+              {status}
             </div>
             {/* Input row */}
-            <form onSubmit={handleSubmit} className="flex flex-row items-center gap-4 w-full">
-              <Mic className="w-6 h-6 text-blue-400 opacity-80" />
+            <form onSubmit={handleSubmit} className="flex items-center gap-2 w-full">
+              <button
+                type="button"
+                onClick={onVoice}
+                className="p-2 bg-white/10 rounded-lg border border-white/20"
+              >
+                <Mic className="w-5 h-5 text-white" />
+              </button>
               <input
                 ref={inputRef}
                 type="text"
                 value={input}
                 onChange={e => setInput(e.target.value)}
                 placeholder="Ask DELO anything..."
-                className="flex-1 px-4 py-2 rounded-xl bg-white/20 border border-white/20 text-white placeholder-white/60 focus:outline-none focus:ring-2 focus:ring-blue-400/40 backdrop-blur-md transition-all duration-200"
+                className="flex-grow px-4 py-2 bg-white/10 border border-white/20 rounded-lg text-white placeholder-gray-300 focus:outline-none"
                 disabled={isProcessing}
                 autoFocus
               />
               <button
                 type="submit"
                 disabled={isProcessing || !input.trim()}
-                className="p-2 rounded-full bg-blue-500/80 hover:bg-blue-600/90 transition-colors duration-200 shadow-md"
+                className="p-2 bg-blue-500 hover:bg-blue-600 rounded-lg transition"
               >
                 <Send className="w-5 h-5 text-white" />
               </button>
             </form>
             {/* Pill buttons */}
             {suggestions && suggestions.length > 0 && (
-              <div className="flex flex-row gap-3 mt-2">
+              <div className="flex justify-center gap-2 mt-4">
                 {suggestions.slice(0, 3).map((s) => (
                   <button
                     key={s}
                     onClick={() => onSuggestionClick?.(s)}
-                    className="px-4 py-1 rounded-full bg-white/20 border border-white/20 text-white text-xs font-medium shadow-sm hover:bg-white/30 transition-colors duration-150 backdrop-blur-md"
+                    className="bg-white/10 border border-white/20 text-sm px-3 py-1 rounded-full hover:bg-white/20 transition"
                     type="button"
                   >
                     {s}

--- a/src/renderer/components/Onboarding.tsx
+++ b/src/renderer/components/Onboarding.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface OnboardingProps {
+  onComplete: () => void;
+}
+
+const steps = [
+  { title: 'Welcome to DELO', description: 'Your floating AI assistant' },
+  { title: 'Quick Commands', description: 'Summarize, translate and open apps instantly' },
+  { title: 'Ready to Go', description: 'Press start to launch the assistant' }
+];
+
+const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
+  const [index, setIndex] = useState(0);
+
+  const next = () => {
+    if (index < steps.length - 1) {
+      setIndex(index + 1);
+    } else {
+      onComplete();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={index}
+          initial={{ opacity: 0, scale: 0.9 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.9 }}
+          transition={{ duration: 0.25, ease: 'easeOut' }}
+          className="bg-white/10 backdrop-blur-xl rounded-2xl shadow-xl border border-white/20 p-8 w-80 text-center text-white"
+        >
+          <h2 className="text-lg font-semibold mb-2">{steps[index].title}</h2>
+          <p className="text-sm mb-6">{steps[index].description}</p>
+          <button
+            onClick={next}
+            className="px-4 py-2 bg-blue-500 hover:bg-blue-600 rounded-lg transition"
+          >
+            {index < steps.length - 1 ? 'Next' : 'Start'}
+          </button>
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default Onboarding;


### PR DESCRIPTION
## Summary
- integrate minimal onboarding flow with localStorage persistence
- show DELOAssistantPanel after onboarding with Alt+Shift+Space hotkey
- remove missing FloatingOrb import

## Testing
- `npm run test:performance` *(fails: Cannot find module 'test-performance.js')*

------
https://chatgpt.com/codex/tasks/task_e_6863969df64c8325bd48049dbb8bb119